### PR TITLE
feat: NPF-2894 modify action to support provided files rather than excuting command itself

### DIFF
--- a/__tests__/DiffChecker.test.ts
+++ b/__tests__/DiffChecker.test.ts
@@ -1,4 +1,4 @@
-import { DiffChecker } from '../src/DiffChecker'
+import {DiffChecker} from '../src/DiffChecker'
 
 describe('DiffChecker', () => {
   const mock100Coverage = {
@@ -77,9 +77,9 @@ describe('DiffChecker', () => {
       ' :x: | ~~file4~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~'
     ])
   })
-  describe("testing checkIfTestCoverageFallsBelowDelta", () => {
-    describe("respects total_delta for total and delta for other files", () => {
-      it("returns true because delta diff is too high, even if total_delta is okay", () => {
+  describe('testing checkIfTestCoverageFallsBelowDelta', () => {
+    describe('respects total_delta for total and delta for other files', () => {
+      it('returns true because delta diff is too high, even if total_delta is okay', () => {
         const codeCoverageOld = {
           total: mock100CoverageFile,
           file1: mock100CoverageFile
@@ -89,10 +89,13 @@ describe('DiffChecker', () => {
           file1: mock98CoverageFile
         }
         const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
-        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(1, 50)
-        expect(isTestCoverageFallsBelowDelta).toBeTruthy();
+        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(
+          1,
+          50
+        )
+        expect(isTestCoverageFallsBelowDelta).toBeTruthy()
       })
-      it("returns true because total_delta diff is too high, even if delta is okay", () => {
+      it('returns true because total_delta diff is too high, even if delta is okay', () => {
         const codeCoverageOld = {
           total: mock100CoverageFile,
           file1: mock100CoverageFile
@@ -102,10 +105,13 @@ describe('DiffChecker', () => {
           file1: mock98CoverageFile
         }
         const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
-        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(50, 1)
-        expect(isTestCoverageFallsBelowDelta).toBeTruthy();
+        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(
+          50,
+          1
+        )
+        expect(isTestCoverageFallsBelowDelta).toBeTruthy()
       })
-      it("returns true if delta diff is too high - total_delta is not defined", () => {
+      it('returns true if delta diff is too high - total_delta is not defined', () => {
         const codeCoverageOld = {
           total: mock100CoverageFile,
           file1: mock100CoverageFile
@@ -115,10 +121,13 @@ describe('DiffChecker', () => {
           file1: mock98CoverageFile
         }
         const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
-        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(1, null)
-        expect(isTestCoverageFallsBelowDelta).toBeTruthy();
+        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(
+          1,
+          null
+        )
+        expect(isTestCoverageFallsBelowDelta).toBeTruthy()
       })
-      it("returns false if total_delta and delta are okay", () => {
+      it('returns false if total_delta and delta are okay', () => {
         const codeCoverageOld = {
           total: mock100CoverageFile,
           file1: mock100CoverageFile
@@ -128,10 +137,13 @@ describe('DiffChecker', () => {
           file1: mock98CoverageFile
         }
         const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
-        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(50, 50)
-        expect(isTestCoverageFallsBelowDelta).toBeFalsy();
+        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(
+          50,
+          50
+        )
+        expect(isTestCoverageFallsBelowDelta).toBeFalsy()
       })
-      it("returns false if delta is okay - total_delta is not defined", () => {
+      it('returns false if delta is okay - total_delta is not defined', () => {
         const codeCoverageOld = {
           total: mock100CoverageFile,
           file1: mock100CoverageFile
@@ -141,54 +153,68 @@ describe('DiffChecker', () => {
           file1: mock98CoverageFile
         }
         const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
-        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(50, null)
-        expect(isTestCoverageFallsBelowDelta).toBeFalsy();
+        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(
+          50,
+          null
+        )
+        expect(isTestCoverageFallsBelowDelta).toBeFalsy()
       })
     })
-    it("detects that total coverage dropped below total_delta", () => {
+    it('detects that total coverage dropped below total_delta', () => {
       const codeCoverageOld = {
-        total: mock100CoverageFile,
+        total: mock100CoverageFile
       }
       const codeCoverageNew = {
-        total: mock98CoverageFile,
+        total: mock98CoverageFile
       }
       const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
-      const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(2, 1)
-      expect(isTestCoverageFallsBelowDelta).toBeTruthy();
+      const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(
+        2,
+        1
+      )
+      expect(isTestCoverageFallsBelowDelta).toBeTruthy()
     })
-    it("detects that total coverage did not drop below total_delta", () => {
+    it('detects that total coverage did not drop below total_delta', () => {
       const codeCoverageOld = {
-        total: mock100CoverageFile,
+        total: mock100CoverageFile
       }
       const codeCoverageNew = {
-        total: mock98CoverageFile,
+        total: mock98CoverageFile
       }
       const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
-      const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(1, 5)
-      expect(isTestCoverageFallsBelowDelta).toBeFalsy();
+      const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(
+        1,
+        5
+      )
+      expect(isTestCoverageFallsBelowDelta).toBeFalsy()
     })
-    it("detects that total coverage dropped below delta", () => {
+    it('detects that total coverage dropped below delta', () => {
       const codeCoverageOld = {
-        total: mock100CoverageFile,
+        total: mock100CoverageFile
       }
       const codeCoverageNew = {
-        total: mock98CoverageFile,
+        total: mock98CoverageFile
       }
       const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
-      const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(1, null)
-      expect(isTestCoverageFallsBelowDelta).toBeTruthy();
+      const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(
+        1,
+        null
+      )
+      expect(isTestCoverageFallsBelowDelta).toBeTruthy()
     })
-    it("detects that total coverage did not drop below delta", () => {
+    it('detects that total coverage did not drop below delta', () => {
       const codeCoverageOld = {
-        total: mock100CoverageFile,
+        total: mock100CoverageFile
       }
       const codeCoverageNew = {
-        total: mock98CoverageFile,
+        total: mock98CoverageFile
       }
       const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
-      const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(2, null)
-      expect(isTestCoverageFallsBelowDelta).toBeFalsy();
+      const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(
+        2,
+        null
+      )
+      expect(isTestCoverageFallsBelowDelta).toBeFalsy()
     })
-
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   fullCoverageDiff:
     description: 'get the full coverage with diff or only the diff'
     default: false
+  autorun:
+    description: Run provided command on both current and target branches
+    default: true
   runCommand:
     description: 'custom command to get json-summary'
     default: 'npx jest --coverage --coverageReporters="json-summary" --coverageDirectory="./"'
@@ -21,8 +24,18 @@ inputs:
     description: 'Difference between the old and final test coverage at the total level'
     default: null
   useSameComment:
-    description: 'While commenting on the PR update the exisiting comment'
+    description: 'While commenting on the PR update the existing comment'
     default: false
+  postComment:
+    description: 'Post comment to the PR'
+    default: true
+  oldCodeCoveragePath:
+    description: 'Path to old code coverage report in json-summary format'
+  newCodeCoveragePath:
+    description: 'Path to old code coverage report in json-summary format'
+outputs:
+  report:
+    description: Coverage report in markdown format
 branding:
   color: red
   icon: git-pull-request

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "jest-coverage-diff",
+  "name": "coverage-diff",
   "version": "0.0.0",
   "private": true,
-  "description": "A github action to comment jest coverage diff on a PR",
+  "description": "A github action to comment coverage diff on a PR",
   "main": "src/main.ts",
   "scripts": {
     "build": "tsc",
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/anuraag016/Jest-Coverage-Diff"
+    "url": "git+https://github.com/namecheap/Coverage-Diff"
   },
   "keywords": [
     "actions",

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -9,6 +9,7 @@ const increasedCoverageIcon = ':green_circle:'
 const decreasedCoverageIcon = ':red_circle:'
 const newCoverageIcon = ':sparkles: :new:'
 const removedCoverageIcon = ':x:'
+const notChangedIcon = ':heavy_minus_sign:'
 
 export class DiffChecker {
   private diffCoverageReport: DiffCoverageReport = {}
@@ -56,7 +57,7 @@ export class DiffChecker {
       } else {
         if (!diffOnly) {
           returnStrings.push(
-            `${key.replace(currentDirectory, '')} | ${
+            `${notChangedIcon} | ${key.replace(currentDirectory, '')} | ${
               this.diffCoverageReport[key].statements.newPct
             } | ${this.diffCoverageReport[key].branches.newPct} | ${
               this.diffCoverageReport[key].functions.newPct


### PR DESCRIPTION
modify action to support provided files rather than excuting command itself
add input autorun -  Run provided command on both current and target branches; defaults to true add inputs for coverage reports
add input postComment -  Post comment to the PR'; defaults true add output report